### PR TITLE
Add FIDO2 demo

### DIFF
--- a/my-capacitor-app/src/main.js
+++ b/my-capacitor-app/src/main.js
@@ -14,6 +14,8 @@ document.querySelector('#app').innerHTML = `
     <h1>Hello Vite!</h1>
     <div class="card">
       <button id="counter" type="button"></button>
+      <button id="register" type="button">Register Passkey</button>
+      <button id="login" type="button">Login Passkey</button>
     </div>
     <p class="read-the-docs">
       Click on the Vite logo to learn more
@@ -21,4 +23,86 @@ document.querySelector('#app').innerHTML = `
   </div>
 `
 
+function getRandomBuffer(len) {
+  const buf = new Uint8Array(len);
+  window.crypto.getRandomValues(buf);
+  return buf;
+}
+
+function arrayBufferToBase64(buffer) {
+  return btoa(String.fromCharCode(...new Uint8Array(buffer)));
+}
+
+function base64ToArrayBuffer(base64) {
+  const binary = atob(base64);
+  const buf = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    buf[i] = binary.charCodeAt(i);
+  }
+  return buf.buffer;
+}
+
+async function registerPasskey() {
+  if (!window.PublicKeyCredential) {
+    alert('WebAuthn not supported');
+    return;
+  }
+  const challenge = getRandomBuffer(32);
+  const userId = getRandomBuffer(32);
+  const options = {
+    publicKey: {
+      rp: { name: 'My Capacitor App' },
+      user: {
+        id: userId,
+        name: 'user@example.com',
+        displayName: 'User Example'
+      },
+      pubKeyCredParams: [{ type: 'public-key', alg: -7 }],
+      authenticatorSelection: { authenticatorAttachment: 'platform' },
+      attestation: 'none',
+      timeout: 60000,
+      challenge
+    }
+  };
+  try {
+    const credential = await navigator.credentials.create(options);
+    const credId = arrayBufferToBase64(credential.rawId);
+    localStorage.setItem('passkeyId', credId);
+    alert('Passkey registered!');
+  } catch (err) {
+    console.error(err);
+    alert('Registration failed: ' + err);
+  }
+}
+
+async function loginPasskey() {
+  const credIdBase64 = localStorage.getItem('passkeyId');
+  if (!credIdBase64) {
+    alert('No passkey registered');
+    return;
+  }
+  const challenge = getRandomBuffer(32);
+  const options = {
+    publicKey: {
+      challenge,
+      timeout: 60000,
+      allowCredentials: [
+        {
+          id: base64ToArrayBuffer(credIdBase64),
+          type: 'public-key'
+        }
+      ]
+    }
+  };
+  try {
+    await navigator.credentials.get(options);
+    alert('Authentication succeeded!');
+  } catch (err) {
+    console.error(err);
+    alert('Authentication failed: ' + err);
+  }
+}
+
 setupCounter(document.querySelector('#counter'))
+document.getElementById('register').addEventListener('click', registerPasskey)
+document.getElementById('login').addEventListener('click', loginPasskey)


### PR DESCRIPTION
## Summary
- integrate a simple FIDO2 demo using WebAuthn API
- add 'Register Passkey' and 'Login Passkey' buttons
- provide helper functions for passkey registration and authentication

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_68793567ee1c832c91dab52fb2b46aa6