### PR TITLE
Add FIDO2 sample for Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# My Capacitor App
+
+This example demonstrates basic Passkey (FIDO2) usage with Capacitor. The web implementation uses the WebAuthn APIs and the Android implementation relies on the `@joyid/capacitor-native-passkey` plugin.
+
+## Android Testing
+
+1. Install dependencies and build the Android project via Capacitor.
+2. Run the application on an Android device or emulator.
+3. Use the **Register Passkey** and **Login Passkey** buttons to create and authenticate a passkey using the native FIDO2 capabilities.
+
+The buttons automatically use the native plugin when running on Android and fall back to WebAuthn in a browser.

--- a/my-capacitor-app/android/app/build.gradle
+++ b/my-capacitor-app/android/app/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     implementation "androidx.coordinatorlayout:coordinatorlayout:$androidxCoordinatorLayoutVersion"
     implementation "androidx.core:core-splashscreen:$coreSplashScreenVersion"
     implementation project(':capacitor-android')
+    implementation "com.google.android.gms:play-services-fido:20.2.0"
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"


### PR DESCRIPTION
## Summary
- integrate `@joyid/capacitor-native-passkey` in the JS app
- add Android dependency for Google FIDO2 library
- document passkey usage in a new README

## Testing
- No tests run per user request

------
https://chatgpt.com/codex/tasks/task_e_687939adf608832c858f5f961d4f95b9